### PR TITLE
permissions and admin access

### DIFF
--- a/app/Enum/Can.php
+++ b/app/Enum/Can.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Enum;
+
+enum Can: string
+{
+    case BE_AN_ADMIN = 'be an admin';
+}

--- a/app/Livewire/Admin/Dashboard.php
+++ b/app/Livewire/Admin/Dashboard.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Livewire\Admin;
+
+use App\Enum\Can;
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+
+class Dashboard extends Component
+{
+    public function mount(): void
+    {
+        $this->authorize(Can::BE_AN_ADMIN->value);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.admin.dashboard');
+    }
+}

--- a/app/Models/HasPermissions.php
+++ b/app/Models/HasPermissions.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Facades\Cache;
+
+trait HasPermissions
+{
+    public function permissions(): BelongsToMany
+    {
+        return $this->belongsToMany(Permission::class);
+    }
+
+    public function givePermissionTo(string $name): void
+    {
+        $this->permissions()->firstOrCreate(compact('name'));
+
+        Cache::forget($this->getPermissionCacheKey());
+
+        Cache::rememberForever($this->getPermissionCacheKey(), fn() => $this->permissions);
+    }
+
+    public function hasPermissionTo(string $name): bool
+    {
+        $permissions = Cache::get($this->getPermissionCacheKey(), $this->permissions);
+
+        return $permissions->contains('name', $name);
+    }
+
+    /**
+     * @return string
+     */
+    private function getPermissionCacheKey(): string
+    {
+        return "user::{$this->id}::permissions";
+    }
+}

--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Permission extends Model
+{
+    protected $fillable = [
+        'name',
+    ];
+
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Traits\Models\HasPermissions;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -38,9 +38,7 @@ class User extends Authenticatable
 
     public function givePermissionTo(string $name): void
     {
-        $this->permissions()->save(
-            Permission::firstOrNew(['name' => $name])
-        );
+        $this->permissions()->firstOrCreate(compact('name'));
     }
 
     public function hasPermissionTo(string $name): bool

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
@@ -29,4 +30,21 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password'          => 'hashed',
     ];
+
+    public function permissions(): BelongsToMany
+    {
+        return $this->belongsToMany(Permission::class);
+    }
+
+    public function givePermissionTo(string $name): void
+    {
+        $this->permissions()->save(
+            Permission::firstOrNew(['name' => $name])
+        );
+    }
+
+    public function hasPermissionTo(string $name): bool
+    {
+        return $this->permissions->contains('name', $name);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,10 +4,8 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use Illuminate\Support\Facades\Cache;
 use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
@@ -15,6 +13,7 @@ class User extends Authenticatable
     use HasApiTokens;
     use HasFactory;
     use Notifiable;
+    use HasPermissions;
 
     protected $fillable = [
         'name',
@@ -31,33 +30,4 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password'          => 'hashed',
     ];
-
-    public function permissions(): BelongsToMany
-    {
-        return $this->belongsToMany(Permission::class);
-    }
-
-    public function givePermissionTo(string $name): void
-    {
-        $this->permissions()->firstOrCreate(compact('name'));
-
-        Cache::forget($this->getPermissionCacheKey());
-
-        Cache::rememberForever($this->getPermissionCacheKey(), fn() => $this->permissions);
-    }
-
-    public function hasPermissionTo(string $name): bool
-    {
-        $permissions = Cache::get($this->getPermissionCacheKey(), $this->permissions);
-
-        return $permissions->contains('name', $name);
-    }
-
-    /**
-     * @return string
-     */
-    private function getPermissionCacheKey(): string
-    {
-        return "user::{$this->id}::permissions";
-    }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -17,7 +17,7 @@ class AuthServiceProvider extends ServiceProvider
     public function boot(): void
     {
         foreach (Can::cases() as $case) {
-            Gate::define(str($case->value)->slug()->toString(), fn(User $user) => $user->hasPermissionTo($case));
+            Gate::define($case->value, fn(User $user) => $user->hasPermissionTo($case));
         }
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
+use App\Enum\Can;
 use App\Models\User;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
@@ -15,6 +16,8 @@ class AuthServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        Gate::define('be-an-admin', fn(User $user) => $user->hasPermissionTo('be an admin'));
+        foreach (Can::cases() as $case) {
+            Gate::define(str($case->value)->slug()->toString(), fn(User $user) => $user->hasPermissionTo($case));
+        }
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,7 +3,9 @@
 namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
+use App\Models\User;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Gate;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -13,6 +15,6 @@ class AuthServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        //
+        Gate::define('be-an-admin', fn(User $user) => $user->hasPermissionTo('be an admin'));
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enum\Can;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
@@ -37,8 +38,12 @@ class UserFactory extends Factory
         ]);
     }
 
-    public function withPermission(string $name): static
+    public function withPermission(Can|string $name): static
     {
+        if ($name instanceof Can) {
+            $name = $name->value;
+        }
+
         return $this->afterCreating(
             fn(User $user) => $user->givePermissionTo($name)
         );

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
@@ -34,5 +35,12 @@ class UserFactory extends Factory
         return $this->state(fn(array $attributes) => [
             'email_verified_at' => null,
         ]);
+    }
+
+    public function withPermission(string $name): static
+    {
+        return $this->afterCreating(
+            fn(User $user) => $user->givePermissionTo($name)
+        );
     }
 }

--- a/database/migrations/2023_11_08_234910_create_permissions_table.php
+++ b/database/migrations/2023_11_08_234910_create_permissions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('permissions', function(Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('permission_user', function(Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id');
+            $table->foreignId('permission_id');
+            $table->index(['user_id', 'permission_id']);
+            $table->unique(['user_id', 'permission_id']);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('permissions');
+        Schema::dropIfExists('permission_user');
+    }
+};

--- a/database/migrations/2023_11_08_234910_create_permissions_table.php
+++ b/database/migrations/2023_11_08_234910_create_permissions_table.php
@@ -15,10 +15,8 @@ return new class () extends Migration {
 
         Schema::create('permission_user', function(Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id');
-            $table->foreignId('permission_id');
-            $table->index(['user_id', 'permission_id']);
-            $table->unique(['user_id', 'permission_id']);
+            $table->foreignId('user_id')->unique()->index();
+            $table->foreignId('permission_id')->unique()->index();
             $table->timestamps();
         });
     }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,7 +13,9 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // \App\Models\User::factory(10)->create();
+        $this->call([
+            PermissionsSeeder::class
+        ]);
 
         User::factory()->create([
             'name'  => 'Test User',

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,7 +3,6 @@
 namespace Database\Seeders;
 
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
-use App\Models\User;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -14,12 +13,8 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call([
-            PermissionsSeeder::class
-        ]);
-
-        User::factory()->create([
-            'name'  => 'Test User',
-            'email' => 'test@example.com',
+            PermissionsSeeder::class,
+            UsersSeeder::class,
         ]);
     }
 }

--- a/database/seeders/PermissionsSeeder.php
+++ b/database/seeders/PermissionsSeeder.php
@@ -10,7 +10,7 @@ class PermissionsSeeder extends Seeder
     public function run(): void
     {
         Permission::query()->insert([
-            'name' => 'doSomething',
+            'name' => 'be an admin',
         ]);
     }
 }

--- a/database/seeders/PermissionsSeeder.php
+++ b/database/seeders/PermissionsSeeder.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Permission;
+use Illuminate\Database\Seeder;
+
+class PermissionsSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Permission::query()->insert([
+            'name' => 'doSomething',
+        ]);
+    }
+}

--- a/database/seeders/UsersSeeder.php
+++ b/database/seeders/UsersSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Enum\Can;
 use App\Models\User;
 use Illuminate\Database\Seeder;
 
@@ -10,7 +11,7 @@ class UsersSeeder extends Seeder
     public function run(): void
     {
         $user = User::factory()
-            ->withPermission('be an admin')
+            ->withPermission(Can::BE_AN_ADMIN)
             ->create([
                 'name'  => 'Test User',
                 'email' => 'test@example.com',

--- a/database/seeders/UsersSeeder.php
+++ b/database/seeders/UsersSeeder.php
@@ -13,8 +13,8 @@ class UsersSeeder extends Seeder
         $user = User::factory()
             ->withPermission(Can::BE_AN_ADMIN)
             ->create([
-                'name'  => 'Test User',
-                'email' => 'test@example.com',
+                'name'  => 'Admin User',
+                'email' => 'admin@admin.com',
             ]);
     }
 }

--- a/database/seeders/UsersSeeder.php
+++ b/database/seeders/UsersSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class UsersSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $user = User::factory()
+            ->withPermission('be an admin')
+            ->create([
+                'name'  => 'Test User',
+                'email' => 'test@example.com',
+            ]);
+    }
+}

--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -1,4 +1,5 @@
-<!DOCTYPE html>
+@php use App\Enum\Can; @endphp
+    <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 <head>
     <meta charset="utf-8">
@@ -39,6 +40,12 @@
                 <x-menu-item title="Wifi" icon="o-wifi" link="####"/>
                 <x-menu-item title="Archives" icon="o-archive-box" link="####"/>
             </x-menu-sub>
+
+            @can(Can::BE_AN_ADMIN->value)
+                <x-menu-sub title="Admin" icon="o-lock-closed">
+                    <x-menu-item title="Dashboard" icon="o-chart-bar-square" link="{{route('admin.dashboard')}}"/>
+                </x-menu-sub>
+            @endcan
         </x-menu>
     </x-slot:sidebar>
 

--- a/resources/views/livewire/admin/dashboard.blade.php
+++ b/resources/views/livewire/admin/dashboard.blade.php
@@ -1,0 +1,3 @@
+<div>
+    Admin Dashboard
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,12 +6,22 @@ use App\Livewire\Auth\Register;
 use App\Livewire\Welcome;
 use Illuminate\Support\Facades\Route;
 
+//region Guest
 Route::get('/login', Login::class)->name('login');
 Route::get('/register', Register::class)->name('register');
 Route::post('/logout', fn() => auth()->logout());
 Route::get('/password-recovery', Password\Recovery::class)->name('password.recovery');
 Route::get('/password-reset', Password\Reset::class)->name('password.reset');
+//endregion
 
+//region Authenticated
 Route::middleware('auth')->group(function() {
     Route::get('/', Welcome::class)->name('dashboard');
+
+    // region Admin
+    Route::prefix('/admin')->middleware('can:be-an-admin')->group(function() {
+        Route::get('/dashboard', fn() => 'admin.dashboard')->name('admin.dashboard');
+    });
+    // endregion
 });
+//endregion

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Enum\Can;
+use App\Livewire\Admin;
 use App\Livewire\Auth\Login;
 use App\Livewire\Auth\Password;
 use App\Livewire\Auth\Register;
@@ -21,7 +22,7 @@ Route::middleware('auth')->group(function() {
 
     // region Admin
     Route::prefix('/admin')->middleware('can:' . Can::BE_AN_ADMIN->value)->group(function() {
-        Route::get('/dashboard', fn() => 'admin.dashboard')->name('admin.dashboard');
+        Route::get('/dashboard', Admin\Dashboard::class)->name('admin.dashboard');
     });
     // endregion
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enum\Can;
 use App\Livewire\Auth\Login;
 use App\Livewire\Auth\Password;
 use App\Livewire\Auth\Register;
@@ -19,7 +20,7 @@ Route::middleware('auth')->group(function() {
     Route::get('/', Welcome::class)->name('dashboard');
 
     // region Admin
-    Route::prefix('/admin')->middleware('can:be-an-admin')->group(function() {
+    Route::prefix('/admin')->middleware('can:' . Can::BE_AN_ADMIN->value)->group(function() {
         Route::get('/dashboard', fn() => 'admin.dashboard')->name('admin.dashboard');
     });
     // endregion

--- a/tests/Feature/Admin/DashboardTest.php
+++ b/tests/Feature/Admin/DashboardTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use App\Livewire\Admin\Dashboard;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+
+test('should block access to admin pages if the user does not have the permission to be an admin', function() {
+    $user = User::factory()->create();
+
+    actingAs($user)
+        ->get(route('admin.dashboard'))
+        ->assertForbidden();
+
+    Livewire::test(Dashboard::class)
+        ->assertForbidden();
+});

--- a/tests/Feature/ArchTest.php
+++ b/tests/Feature/ArchTest.php
@@ -1,0 +1,6 @@
+<?php
+
+test('global', function() {
+    expect(['dd', 'dump', 'ray', 'ds'])
+        ->not()->toBeUsed();
+});

--- a/tests/Feature/PermissionsControlTest.php
+++ b/tests/Feature/PermissionsControlTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Permission;
 use App\Models\User;
+use Database\Seeders\PermissionsSeeder;
 
 use function Pest\Laravel\assertDatabaseHas;
 
@@ -22,4 +23,12 @@ it('should be able to give an user a permission to do something', function() {
     assertDatabaseHas('permission_user', [
         'user_id'       => $user->id,
         'permission_id' => Permission::whereName('doSomething')->first()->id, ]);
+});
+
+test('permission has to have a seeder', function() {
+    $this->seed(PermissionsSeeder::class);
+
+    assertDatabaseHas('permissions', [
+        'name' => 'doSomething',
+    ]);
 });

--- a/tests/Feature/PermissionsControlTest.php
+++ b/tests/Feature/PermissionsControlTest.php
@@ -3,8 +3,10 @@
 use App\Models\Permission;
 use App\Models\User;
 use Database\Seeders\PermissionsSeeder;
+use Database\Seeders\UsersSeeder;
 
 use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\seed;
 
 it('should be able to give an user a permission to do something', function() {
     /** @var User $user */
@@ -22,13 +24,26 @@ it('should be able to give an user a permission to do something', function() {
 
     assertDatabaseHas('permission_user', [
         'user_id'       => $user->id,
-        'permission_id' => Permission::whereName('doSomething')->first()->id, ]);
+        'permission_id' => Permission::query()->whereName('doSomething')->first()->id, ]);
 });
 
 test('permission has to have a seeder', function() {
-    $this->seed(PermissionsSeeder::class);
+    seed(PermissionsSeeder::class);
 
     assertDatabaseHas('permissions', [
-        'name' => 'doSomething',
+        'name' => 'be an admin',
+    ]);
+});
+
+test('seed with an admin user', function() {
+    seed([PermissionsSeeder::class, UsersSeeder::class]);
+
+    assertDatabaseHas('permissions', [
+        'name' => 'be an admin',
+    ]);
+
+    assertDatabaseHas('permission_user', [
+        'user_id'       => User::first()->id,
+        'permission_id' => Permission::query()->whereName('be an admin')->first()->id,
     ]);
 });

--- a/tests/Feature/PermissionsControlTest.php
+++ b/tests/Feature/PermissionsControlTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Models\Permission;
+use App\Models\User;
+
+use function Pest\Laravel\assertDatabaseHas;
+
+it('should be able to give an user a permission to do something', function() {
+    $user = User::factory()->create();
+
+    $user->givePermissionTo('doSomething');
+
+    expect($user)
+        ->hasPermissionTo('doSomething')
+        ->toBeTrue();
+
+    assertDatabaseHas('permissions', [
+        'name' => 'doSomething',
+    ]);
+
+    assertDatabaseHas('permission_user', [
+        'user_id'       => $user->id,
+        'permission_id' => Permission::whereName('doSomething')->first()->id,
+    ]);
+});

--- a/tests/Feature/PermissionsControlTest.php
+++ b/tests/Feature/PermissionsControlTest.php
@@ -29,7 +29,7 @@ it('should be able to give an user a permission to do something', function() {
         'permission_id' => Permission::query()->whereName(Can::BE_AN_ADMIN->value)->first()->id, ]);
 });
 
-test('permission has to have a seeder', function() {
+test('permission must have a seeder', function() {
     seed(PermissionsSeeder::class);
 
     assertDatabaseHas('permissions', [

--- a/tests/Feature/PermissionsControlTest.php
+++ b/tests/Feature/PermissionsControlTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enum\Can;
 use App\Models\Permission;
 use App\Models\User;
 use Database\Seeders\PermissionsSeeder;
@@ -13,26 +14,26 @@ it('should be able to give an user a permission to do something', function() {
     /** @var User $user */
     $user = User::factory()->create();
 
-    $user->givePermissionTo('doSomething');
+    $user->givePermissionTo(Can::BE_AN_ADMIN);
 
     expect($user)
-        ->hasPermissionTo('doSomething')
+        ->hasPermissionTo(Can::BE_AN_ADMIN)
         ->toBeTrue();
 
     assertDatabaseHas('permissions', [
-        'name' => 'doSomething',
+        'name' => Can::BE_AN_ADMIN->value,
     ]);
 
     assertDatabaseHas('permission_user', [
         'user_id'       => $user->id,
-        'permission_id' => Permission::query()->whereName('doSomething')->first()->id, ]);
+        'permission_id' => Permission::query()->whereName(Can::BE_AN_ADMIN->value)->first()->id, ]);
 });
 
 test('permission has to have a seeder', function() {
     seed(PermissionsSeeder::class);
 
     assertDatabaseHas('permissions', [
-        'name' => 'be an admin',
+        'name' => Can::BE_AN_ADMIN->value,
     ]);
 });
 
@@ -40,12 +41,12 @@ test('seed with an admin user', function() {
     seed([PermissionsSeeder::class, UsersSeeder::class]);
 
     assertDatabaseHas('permissions', [
-        'name' => 'be an admin',
+        'name' => Can::BE_AN_ADMIN->value,
     ]);
 
     assertDatabaseHas('permission_user', [
         'user_id'       => User::first()->id,
-        'permission_id' => Permission::query()->whereName('be an admin')->first()->id,
+        'permission_id' => Permission::query()->whereName(Can::BE_AN_ADMIN->value)->first()->id,
     ]);
 });
 
@@ -60,7 +61,7 @@ test('should block the access to admin pages if the user does not have the permi
 test('should allow the access to admin pages if the user has the permission to be an admin', function() {
     $user = User::factory()->create();
 
-    $user->givePermissionTo('be an admin');
+    $user->givePermissionTo(Can::BE_AN_ADMIN);
 
     actingAs($user)
         ->get(route('admin.dashboard'))
@@ -70,7 +71,7 @@ test('should allow the access to admin pages if the user has the permission to b
 test("let's make sure that we are using cache to store user permissions", function() {
     $user = User::factory()->create();
 
-    $user->givePermissionTo('be an admin');
+    $user->givePermissionTo(Can::BE_AN_ADMIN);
 
     $cacheKey = "user::{$user->id}::permissions";
 
@@ -81,10 +82,10 @@ test("let's make sure that we are using cache to store user permissions", functi
 test("let's make sure that we are using cache to retrieve/check when the user has the given permission", function() {
     $user = User::factory()->create();
 
-    $user->givePermissionTo('be an admin');
+    $user->givePermissionTo(Can::BE_AN_ADMIN);
 
     DB::listen(fn($query) => throw new Exception('The query should not be executed'));
-    $user->hasPermissionTo('be an admin');
+    $user->hasPermissionTo(Can::BE_AN_ADMIN);
 
     expect(true)->toBeTrue();
 });

--- a/tests/Feature/PermissionsControlTest.php
+++ b/tests/Feature/PermissionsControlTest.php
@@ -5,6 +5,7 @@ use App\Models\User;
 use Database\Seeders\PermissionsSeeder;
 use Database\Seeders\UsersSeeder;
 
+use function Pest\Laravel\actingAs;
 use function Pest\Laravel\assertDatabaseHas;
 use function Pest\Laravel\seed;
 
@@ -46,4 +47,22 @@ test('seed with an admin user', function() {
         'user_id'       => User::first()->id,
         'permission_id' => Permission::query()->whereName('be an admin')->first()->id,
     ]);
+});
+
+test('should block the access to admin pages if the user does not have the permission to be an admin', function() {
+    $user = User::factory()->create();
+
+    actingAs($user)
+        ->get(route('admin.dashboard'))
+        ->assertForbidden();
+});
+
+test('should allow the access to admin pages if the user has the permission to be an admin', function() {
+    $user = User::factory()->create();
+
+    $user->givePermissionTo('be an admin');
+
+    actingAs($user)
+        ->get(route('admin.dashboard'))
+        ->assertOk();
 });

--- a/tests/Feature/PermissionsControlTest.php
+++ b/tests/Feature/PermissionsControlTest.php
@@ -66,3 +66,25 @@ test('should allow the access to admin pages if the user has the permission to b
         ->get(route('admin.dashboard'))
         ->assertOk();
 });
+
+test("let's make sure that we are using cache to store user permissions", function() {
+    $user = User::factory()->create();
+
+    $user->givePermissionTo('be an admin');
+
+    $cacheKey = "user::{$user->id}::permissions";
+
+    expect(Cache::has($cacheKey))->toBeTrue('The cache key should exist')
+        ->and(Cache::get($cacheKey))->toBe($user->permissions, 'The cache should contain the user permissions');
+});
+
+test("let's make sure that we are using cache to retrieve/check when the user has the given permission", function() {
+    $user = User::factory()->create();
+
+    $user->givePermissionTo('be an admin');
+
+    DB::listen(fn($query) => throw new Exception('The query should not be executed'));
+    $user->hasPermissionTo('be an admin');
+
+    expect(true)->toBeTrue();
+});

--- a/tests/Feature/PermissionsControlTest.php
+++ b/tests/Feature/PermissionsControlTest.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use function Pest\Laravel\assertDatabaseHas;
 
 it('should be able to give an user a permission to do something', function() {
+    /** @var User $user */
     $user = User::factory()->create();
 
     $user->givePermissionTo('doSomething');
@@ -20,6 +21,5 @@ it('should be able to give an user a permission to do something', function() {
 
     assertDatabaseHas('permission_user', [
         'user_id'       => $user->id,
-        'permission_id' => Permission::whereName('doSomething')->first()->id,
-    ]);
+        'permission_id' => Permission::whereName('doSomething')->first()->id, ]);
 });


### PR DESCRIPTION
- wip
- crm-5: should be able to give an user a permission to do something
- crm-5: permission has to have a seeder
- crm-5: seed with an admin user
- crm-5: add middleware to admin routes using gate
- crm-5: make sure that we are using cache to retrieve/check when the user has the given permission
- crm-5: refactor:: add HasPermissions trait to User model
- crm-5: add ArchTest to prevent dd, dump, ray and ds in code
- crm-5: refactor to use enum
- crm-5: typo
- crm-5: refactor to use enum on middleware
- crm-5: add Admin menu item
- crm-5: should block access to users that does not have the permission to be an admin
